### PR TITLE
Harden GitHub Pages deploy and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,23 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
     name: Typecheck & Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -29,4 +30,6 @@ jobs:
         run: pnpm typecheck
 
       - name: Build
+        env:
+          BASE_PATH: /certuary/
         run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,43 +10,49 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: deploy-pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Build
         env:
           BASE_PATH: /certuary/
         run: pnpm build
 
-      - uses: actions/upload-pages-artifact@v3
+      - name: Verify build output
+        run: test -f apps/web/dist/index.html || (echo "Missing index.html" && exit 1)
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: apps/web/dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "certuary",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.11.0",
   "scripts": {
     "generate": "pnpm --filter @certuary/data generate",
     "dev": "pnpm generate && pnpm --filter @certuary/web dev",


### PR DESCRIPTION
- Pin all actions to commit SHAs to prevent supply chain attacks
- Remove duplicate push-to-main trigger from CI (deploy now typechecks)
- Add typecheck + build verification steps to deploy workflow
- Add BASE_PATH env to CI so it validates the same build as deploy
- Add concurrency groups and timeout-minutes to both workflows
- Add packageManager field to package.json for consistent pnpm version

https://claude.ai/code/session_013SKpHNB3kt5pYUuZ74FB6f