### PR TITLE
Add all 16 Golden Kubestronaut certifications

### DIFF
--- a/packages/data/data/linux-foundation/_index.yaml
+++ b/packages/data/data/linux-foundation/_index.yaml
@@ -1,0 +1,7 @@
+name: The Linux Foundation
+slug: linux-foundation
+website: https://training.linuxfoundation.org/certification/
+description: >-
+  The Linux Foundation offers professional certification programs for
+  Kubernetes, cloud native technologies, and Linux system administration,
+  including the CNCF Kubestronaut and Golden Kubestronaut programs.

--- a/packages/data/data/linux-foundation/capa/_index.yaml
+++ b/packages/data/data/linux-foundation/capa/_index.yaml
@@ -1,0 +1,39 @@
+name: Certified Argo Project Associate
+short_name: CAPA
+slug: capa
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of the Argo project ecosystem including Argo CD,
+  Argo Workflows, Argo Rollouts, and Argo Events for GitOps-based
+  continuous delivery on Kubernetes.
+
+tags:
+  - cloud-native
+  - gitops
+  - continuous-delivery
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cgoa
+  - ckad
+  - cnpe
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-argo-project-associate-capa/
+    type: official
+  - label: CNCF CAPA Page
+    url: https://www.cncf.io/training/certification/capa/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-argo-project-associate-capa/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cba/_index.yaml
+++ b/packages/data/data/linux-foundation/cba/_index.yaml
@@ -1,0 +1,38 @@
+name: Certified Backstage Associate
+short_name: CBA
+slug: cba
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of Backstage, the open platform for building
+  developer portals. Covers software catalog, templates, TechDocs,
+  plugins, and platform engineering concepts.
+
+tags:
+  - cloud-native
+  - platform-engineering
+  - developer-portals
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cnpe
+  - cnpa
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-backstage-associate-cba/
+    type: official
+  - label: CNCF CBA Page
+    url: https://www.cncf.io/training/certification/cba/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-backstage-associate-cba/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cca/_index.yaml
+++ b/packages/data/data/linux-foundation/cca/_index.yaml
@@ -1,0 +1,38 @@
+name: Cilium Certified Associate
+short_name: CCA
+slug: cca
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of Cilium for Kubernetes networking, observability,
+  and security using eBPF technology. Covers network policies, service
+  mesh, cluster mesh, and Hubble observability.
+
+tags:
+  - cloud-native
+  - networking
+  - security
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - ica
+  - cka
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/cilium-certified-associate-cca/
+    type: official
+  - label: CNCF CCA Page
+    url: https://www.cncf.io/training/certification/cca/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/cilium-certified-associate-cca/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cgoa/_index.yaml
+++ b/packages/data/data/linux-foundation/cgoa/_index.yaml
@@ -1,0 +1,39 @@
+name: Certified GitOps Associate
+short_name: CGOA
+slug: cgoa
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates understanding of GitOps principles, practices, and tooling
+  for managing cloud native infrastructure and application delivery
+  using Git as the single source of truth.
+
+tags:
+  - cloud-native
+  - gitops
+  - continuous-delivery
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - capa
+  - cnpe
+  - ckad
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-gitops-associate-cgoa/
+    type: official
+  - label: CNCF CGOA Page
+    url: https://www.cncf.io/training/certification/cgoa/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-gitops-associate-cgoa/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cka/_index.yaml
+++ b/packages/data/data/linux-foundation/cka/_index.yaml
@@ -1,0 +1,42 @@
+name: Certified Kubernetes Administrator
+short_name: CKA
+slug: cka
+status: active
+cost: "$445 USD"
+
+description: >-
+  Validates skills in Kubernetes cluster administration including
+  installation, configuration, networking, storage, security, and
+  troubleshooting. A performance-based exam requiring hands-on tasks
+  in a live Kubernetes environment.
+
+tags:
+  - kubernetes
+  - cloud-native
+  - administration
+  - intermediate
+  - performance-based
+  - kubestronaut
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - kcna
+  - ckad
+  - cks
+  - cnpe
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/
+    type: official
+  - label: CNCF CKA Page
+    url: https://www.cncf.io/training/certification/cka/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/ckad/_index.yaml
+++ b/packages/data/data/linux-foundation/ckad/_index.yaml
@@ -1,0 +1,42 @@
+name: Certified Kubernetes Application Developer
+short_name: CKAD
+slug: ckad
+status: active
+cost: "$445 USD"
+
+description: >-
+  Validates the ability to design, build, configure, and deploy cloud
+  native applications on Kubernetes. A performance-based exam covering
+  application lifecycle management, services, networking, and
+  observability.
+
+tags:
+  - kubernetes
+  - cloud-native
+  - development
+  - intermediate
+  - performance-based
+  - kubestronaut
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - kcna
+  - cka
+  - cks
+  - cnpe
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/
+    type: official
+  - label: CNCF CKAD Page
+    url: https://www.cncf.io/training/certification/ckad/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cks/_index.yaml
+++ b/packages/data/data/linux-foundation/cks/_index.yaml
@@ -1,0 +1,41 @@
+name: Certified Kubernetes Security Specialist
+short_name: CKS
+slug: cks
+status: active
+cost: "$445 USD"
+
+description: >-
+  Validates advanced Kubernetes security skills including cluster hardening,
+  system hardening, supply chain security, monitoring, and runtime security.
+  A performance-based exam requiring hands-on tasks in a live environment.
+
+tags:
+  - kubernetes
+  - cloud-native
+  - security
+  - advanced
+  - performance-based
+  - kubestronaut
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites:
+  - Must hold an active CKA certification
+
+related_certs:
+  - cka
+  - kcsa
+  - kcna
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/
+    type: official
+  - label: CNCF CKS Page
+    url: https://www.cncf.io/training/certification/cks/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cnpa/_index.yaml
+++ b/packages/data/data/linux-foundation/cnpa/_index.yaml
@@ -1,0 +1,36 @@
+name: Certified Cloud Native Platform Engineering Associate
+short_name: CNPA
+slug: cnpa
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates foundational knowledge of platform engineering concepts
+  including internal developer platforms, golden paths, self-service
+  infrastructure, and cloud native tooling for improving developer
+  experience.
+
+tags:
+  - cloud-native
+  - platform-engineering
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cnpe
+  - cba
+  - cgoa
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-cloud-native-platform-engineering-associate-cnpa/
+    type: official
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-cloud-native-platform-engineering-associate-cnpa/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/cnpe/_index.yaml
+++ b/packages/data/data/linux-foundation/cnpe/_index.yaml
@@ -1,0 +1,39 @@
+name: Certified Cloud Native Platform Engineer
+short_name: CNPE
+slug: cnpe
+status: active
+cost: "$445 USD"
+
+description: >-
+  Validates advanced platform engineering skills including designing and
+  operating internal developer platforms, CI/CD pipelines, GitOps
+  workflows, and Kubernetes-based infrastructure. A performance-based
+  exam.
+
+tags:
+  - cloud-native
+  - platform-engineering
+  - advanced
+  - performance-based
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites:
+  - CKA-level Kubernetes expertise recommended
+
+related_certs:
+  - cnpa
+  - cka
+  - ckad
+  - cgoa
+  - cba
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/certified-cloud-native-platform-engineer-cnpe/
+    type: official
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/certified-cloud-native-platform-engineer-cnpe/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/ica/_index.yaml
+++ b/packages/data/data/linux-foundation/ica/_index.yaml
@@ -1,0 +1,38 @@
+name: Istio Certified Associate
+short_name: ICA
+slug: ica
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of Istio service mesh concepts including traffic
+  management, security, observability, and installation in Kubernetes
+  environments. A performance-based exam.
+
+tags:
+  - cloud-native
+  - service-mesh
+  - networking
+  - associate
+  - performance-based
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cca
+  - cka
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/istio-certified-associate-ica/
+    type: official
+  - label: CNCF ICA Page
+    url: https://www.cncf.io/training/certification/ica/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/istio-certified-associate-ica/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/kca/_index.yaml
+++ b/packages/data/data/linux-foundation/kca/_index.yaml
@@ -1,0 +1,38 @@
+name: Kyverno Certified Associate
+short_name: KCA
+slug: kca
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of Kyverno for Kubernetes policy management
+  including policy authoring, validation, mutation, generation, and
+  image verification for cloud native security and compliance.
+
+tags:
+  - cloud-native
+  - policy
+  - security
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cks
+  - kcsa
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/kyverno-certified-associate-kca/
+    type: official
+  - label: CNCF KCA Page
+    url: https://www.cncf.io/training/certification/kca/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/kyverno-certified-associate-kca/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/kcna/_index.yaml
+++ b/packages/data/data/linux-foundation/kcna/_index.yaml
@@ -1,0 +1,40 @@
+name: Kubernetes and Cloud Native Associate
+short_name: KCNA
+slug: kcna
+status: active
+cost: "$250 USD"
+
+description: >-
+  Demonstrates foundational knowledge of Kubernetes and the broader cloud
+  native ecosystem including container orchestration, cloud native
+  architecture, and observability. Entry-level certification for the
+  Kubestronaut path.
+
+tags:
+  - kubernetes
+  - cloud-native
+  - associate
+  - multiple-choice
+  - kubestronaut
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cka
+  - ckad
+  - kcsa
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/kubernetes-cloud-native-associate/
+    type: official
+  - label: CNCF Kubernetes Training
+    url: https://www.cncf.io/training/certification/kcna/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/kubernetes-cloud-native-associate/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/kcsa/_index.yaml
+++ b/packages/data/data/linux-foundation/kcsa/_index.yaml
@@ -1,0 +1,40 @@
+name: Kubernetes and Cloud Native Security Associate
+short_name: KCSA
+slug: kcsa
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of baseline security concepts and their application
+  to Kubernetes and cloud native environments, covering cluster security,
+  supply chain security, and runtime security.
+
+tags:
+  - kubernetes
+  - cloud-native
+  - security
+  - associate
+  - multiple-choice
+  - kubestronaut
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - kcna
+  - cks
+  - cka
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/kubernetes-and-cloud-native-security-associate-kcsa/
+    type: official
+  - label: CNCF KCSA Page
+    url: https://www.cncf.io/training/certification/kcsa/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/kubernetes-and-cloud-native-security-associate-kcsa/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/lfcs/_index.yaml
+++ b/packages/data/data/linux-foundation/lfcs/_index.yaml
@@ -1,0 +1,34 @@
+name: Linux Foundation Certified System Administrator
+short_name: LFCS
+slug: lfcs
+status: active
+cost: "$445 USD"
+
+description: >-
+  Validates the ability to perform Linux system administration tasks
+  including essential commands, file management, user and group
+  management, networking, storage, and service configuration.
+  A performance-based exam using a live Linux environment.
+
+tags:
+  - linux
+  - sysadmin
+  - intermediate
+  - performance-based
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - cka
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/
+    type: official
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/otca/_index.yaml
+++ b/packages/data/data/linux-foundation/otca/_index.yaml
@@ -1,0 +1,39 @@
+name: OpenTelemetry Certified Associate
+short_name: OTCA
+slug: otca
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates knowledge of OpenTelemetry for distributed tracing, metrics,
+  and logging in cloud native applications. Covers the OpenTelemetry
+  Collector, SDKs, instrumentation, and integration with observability
+  backends.
+
+tags:
+  - cloud-native
+  - observability
+  - tracing
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - pca
+  - kcna
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/opentelemetry-certified-associate-otca/
+    type: official
+  - label: CNCF OTCA Page
+    url: https://www.cncf.io/training/certification/otca/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/opentelemetry-certified-associate-otca/
+last_verified: "2026-03-31"

--- a/packages/data/data/linux-foundation/pca/_index.yaml
+++ b/packages/data/data/linux-foundation/pca/_index.yaml
@@ -1,0 +1,38 @@
+name: Prometheus Certified Associate
+short_name: PCA
+slug: pca
+status: active
+cost: "$250 USD"
+
+description: >-
+  Validates foundational knowledge of observability and monitoring using
+  Prometheus, including PromQL, instrumentation, dashboarding, and
+  alerting in cloud native environments.
+
+tags:
+  - cloud-native
+  - observability
+  - monitoring
+  - associate
+  - multiple-choice
+  - golden-kubestronaut
+  - linux-foundation
+
+prerequisites: []
+
+related_certs:
+  - otca
+  - kcna
+
+versions: []
+
+links:
+  - label: Official Certification Page
+    url: https://training.linuxfoundation.org/certification/prometheus-certified-associate/
+    type: official
+  - label: CNCF PCA Page
+    url: https://www.cncf.io/training/certification/pca/
+    type: source-of-truth
+
+source_of_truth_url: https://training.linuxfoundation.org/certification/prometheus-certified-associate/
+last_verified: "2026-03-31"


### PR DESCRIPTION
Add Linux Foundation as a new provider with all certifications required
for the CNCF Golden Kubestronaut program:

Kubernetes Core (Kubestronaut): KCNA, KCSA, CKA, CKAD, CKS
Cloud Native Associates: PCA, ICA, CCA, CAPA, CGOA, CBA
Emerging Technologies: OTCA, KCA, CNPA
Platform Engineering: CNPE
Linux Foundation: LFCS

https://claude.ai/code/session_01DJK4MV4rTYBTDwBA3yfuMa