### PR TITLE
Fix routing with custom base paths in Vite config

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Certuary - IT Certification Explorer</title>
     <!-- SPA redirect handler for GitHub Pages 404.html -->
     <script>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,9 +4,13 @@ import { BrowserRouter } from "react-router";
 import { App } from "./app";
 import "./index.css";
 
+declare const __BASE_PATH__: string;
+
+const basename = __BASE_PATH__.replace(/\/$/, "") || "/";
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,8 +3,13 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+const basePath = process.env.BASE_PATH ?? "/";
+
 export default defineConfig({
-  base: process.env.BASE_PATH ?? "/",
+  base: basePath,
+  define: {
+    __BASE_PATH__: JSON.stringify(basePath),
+  },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
This PR fixes routing behavior when the application is deployed to a custom base path by properly configuring the BrowserRouter basename to match the Vite base configuration.

## Key Changes
- **vite.config.ts**: Extract `BASE_PATH` environment variable into a constant and expose it as a global define variable (`__BASE_PATH__`) so it can be accessed at runtime in the application code
- **main.tsx**: Use the `__BASE_PATH__` global to set the `basename` prop on BrowserRouter, ensuring client-side routing works correctly when deployed to non-root paths. The basename is normalized by removing trailing slashes
- **index.html**: Add an empty favicon link to prevent 404 errors from missing favicon requests

## Implementation Details
The key issue was that Vite's `base` configuration only affects asset loading, not React Router's routing. By exposing the base path as a compile-time constant and passing it to BrowserRouter's `basename` prop, the router now correctly handles navigation and links when the app is deployed to a subdirectory (e.g., GitHub Pages projects).

https://claude.ai/code/session_01UCnzEhTXzEnznHkdBYBoxf