### PR TITLE
Add type and designation fields to certification programs

### DIFF
--- a/apps/web/src/lib/program-labels.ts
+++ b/apps/web/src/lib/program-labels.ts
@@ -1,0 +1,7 @@
+import type { ProgramType } from "@certuary/data";
+
+export const programTypeLabels: Record<ProgramType, string> = {
+  provider: "Provider Program",
+  certuary: "Certuary Path",
+  community: "Community",
+};

--- a/apps/web/src/pages/program-detail.tsx
+++ b/apps/web/src/pages/program-detail.tsx
@@ -54,11 +54,11 @@ export function ProgramDetailPage() {
         <div className="mt-1 flex items-center gap-3">
           <h1 className="text-3xl font-bold">{program.name}</h1>
           <Badge variant="outline">
-            {program.type === "provider"
-              ? "Provider Program"
-              : program.type === "community"
-                ? "Community"
-                : "Certuary Path"}
+            {{
+              provider: "Provider Program",
+              community: "Community",
+              certuary: "Certuary Path",
+            }[program.type]}
           </Badge>
           <Badge
             variant={program.status === "active" ? "default" : "destructive"}
@@ -67,9 +67,9 @@ export function ProgramDetailPage() {
           </Badge>
         </div>
         {program.designation && (
-          <p className="mt-1 text-sm font-medium text-primary">
-            Designation: {program.designation}
-          </p>
+          <div className="mt-2">
+            <Badge variant="default">{program.designation}</Badge>
+          </div>
         )}
         <p className="mt-2 text-muted-foreground">{program.description}</p>
         {program.type === "certuary" && (

--- a/apps/web/src/pages/program-detail.tsx
+++ b/apps/web/src/pages/program-detail.tsx
@@ -53,13 +53,31 @@ export function ProgramDetailPage() {
         </span>
         <div className="mt-1 flex items-center gap-3">
           <h1 className="text-3xl font-bold">{program.name}</h1>
+          <Badge variant="outline">
+            {program.type === "provider"
+              ? "Provider Program"
+              : program.type === "community"
+                ? "Community"
+                : "Certuary Path"}
+          </Badge>
           <Badge
             variant={program.status === "active" ? "default" : "destructive"}
           >
             {program.status}
           </Badge>
         </div>
+        {program.designation && (
+          <p className="mt-1 text-sm font-medium text-primary">
+            Designation: {program.designation}
+          </p>
+        )}
         <p className="mt-2 text-muted-foreground">{program.description}</p>
+        {program.type === "certuary" && (
+          <p className="mt-1 text-xs text-muted-foreground italic">
+            This certification path is curated by the Certuary community and is
+            not an official program from the provider.
+          </p>
+        )}
         <a
           href={program.website}
           target="_blank"

--- a/apps/web/src/pages/program-detail.tsx
+++ b/apps/web/src/pages/program-detail.tsx
@@ -16,6 +16,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { parseCost } from "@/lib/costs";
+import { programTypeLabels } from "@/lib/program-labels";
 
 export function ProgramDetailPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -54,11 +55,7 @@ export function ProgramDetailPage() {
         <div className="mt-1 flex items-center gap-3">
           <h1 className="text-3xl font-bold">{program.name}</h1>
           <Badge variant="outline">
-            {{
-              provider: "Provider Program",
-              community: "Community",
-              certuary: "Certuary Path",
-            }[program.type]}
+            {programTypeLabels[program.type]}
           </Badge>
           <Badge
             variant={program.status === "active" ? "default" : "destructive"}

--- a/apps/web/src/pages/programs.tsx
+++ b/apps/web/src/pages/programs.tsx
@@ -59,6 +59,16 @@ export function ProgramsPage() {
                   </CardHeader>
                   <CardContent>
                     <div className="flex flex-wrap gap-1">
+                      <Badge variant="outline">
+                        {program.type === "provider"
+                          ? "Provider Program"
+                          : program.type === "community"
+                            ? "Community"
+                            : "Certuary Path"}
+                      </Badge>
+                      {program.designation && (
+                        <Badge variant="default">{program.designation}</Badge>
+                      )}
                       <Badge variant="secondary">
                         {program.phases.length} phase
                         {program.phases.length !== 1 && "s"}

--- a/apps/web/src/pages/programs.tsx
+++ b/apps/web/src/pages/programs.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { programTypeLabels } from "@/lib/program-labels";
 
 export function ProgramsPage() {
   const programs = getAllPrograms();
@@ -60,11 +61,7 @@ export function ProgramsPage() {
                   <CardContent>
                     <div className="flex flex-wrap gap-1">
                       <Badge variant="outline">
-                        {{
-                          provider: "Provider Program",
-                          community: "Community",
-                          certuary: "Certuary Path",
-                        }[program.type]}
+                        {programTypeLabels[program.type]}
                       </Badge>
                       {program.designation && (
                         <Badge variant="default">{program.designation}</Badge>

--- a/apps/web/src/pages/programs.tsx
+++ b/apps/web/src/pages/programs.tsx
@@ -60,11 +60,11 @@ export function ProgramsPage() {
                   <CardContent>
                     <div className="flex flex-wrap gap-1">
                       <Badge variant="outline">
-                        {program.type === "provider"
-                          ? "Provider Program"
-                          : program.type === "community"
-                            ? "Community"
-                            : "Certuary Path"}
+                        {{
+                          provider: "Provider Program",
+                          community: "Community",
+                          certuary: "Certuary Path",
+                        }[program.type]}
                       </Badge>
                       {program.designation && (
                         <Badge variant="default">{program.designation}</Badge>

--- a/packages/data/data/apple/programs/apple-certification-path.yaml
+++ b/packages/data/data/apple/programs/apple-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: apple-certification-path
+type: certuary
 name: Apple Certification Path
 description: >-
   A recommended learning path through Apple certifications, from macOS

--- a/packages/data/data/atlassian/programs/atlassian-certification-path.yaml
+++ b/packages/data/data/atlassian/programs/atlassian-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: atlassian-certification-path
+type: certuary
 name: Atlassian Certification Path
 description: >-
   A recommended learning path through Atlassian certifications, from

--- a/packages/data/data/aws/programs/aws-certification-path.yaml
+++ b/packages/data/data/aws/programs/aws-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: aws-certification-path
+type: provider
 name: AWS Certification Path
 description: >-
   A recommended learning path through AWS certifications, from foundational

--- a/packages/data/data/azure/programs/azure-certification-path.yaml
+++ b/packages/data/data/azure/programs/azure-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: azure-certification-path
+type: provider
 name: Azure Certification Path
 description: >-
   Microsoft's tiered certification framework progressing from fundamentals-level

--- a/packages/data/data/cisco/programs/cisco-certification-path.yaml
+++ b/packages/data/data/cisco/programs/cisco-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: cisco-certification-path
+type: provider
 name: Cisco Certification Path
 description: >-
   Cisco's tiered certification framework progressing from associate-level

--- a/packages/data/data/comptia/programs/comptia-certification-path.yaml
+++ b/packages/data/data/comptia/programs/comptia-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: comptia-certification-path
+type: provider
 name: CompTIA Certification Path
 description: >-
   CompTIA's vendor-neutral certification pathway progressing from foundational

--- a/packages/data/data/crest/programs/crest-incident-response-path.yaml
+++ b/packages/data/data/crest/programs/crest-incident-response-path.yaml
@@ -1,4 +1,5 @@
 slug: crest-incident-response-path
+type: provider
 name: CREST Incident Response Certification Path
 description: >-
   The recommended progression through CREST incident response certifications,

--- a/packages/data/data/crest/programs/crest-penetration-testing-path.yaml
+++ b/packages/data/data/crest/programs/crest-penetration-testing-path.yaml
@@ -1,4 +1,5 @@
 slug: crest-penetration-testing-path
+type: provider
 name: CREST Penetration Testing Certification Path
 description: >-
   The recommended progression through CREST penetration testing certifications,

--- a/packages/data/data/crest/programs/crest-threat-intelligence-path.yaml
+++ b/packages/data/data/crest/programs/crest-threat-intelligence-path.yaml
@@ -1,4 +1,5 @@
 slug: crest-threat-intelligence-path
+type: provider
 name: CREST Threat Intelligence Certification Path
 description: >-
   The recommended progression through CREST threat intelligence certifications,

--- a/packages/data/data/crowdstrike/programs/crowdstrike-certification-path.yaml
+++ b/packages/data/data/crowdstrike/programs/crowdstrike-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: crowdstrike-certification-path
+type: certuary
 name: CrowdStrike Certification Path
 description: >-
   A recommended learning path through CrowdStrike certifications, from

--- a/packages/data/data/dell/programs/dell-certification-path.yaml
+++ b/packages/data/data/dell/programs/dell-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: dell-certification-path
+type: provider
 name: Dell Technologies Proven Professional Path
 description: >-
   A recommended learning path through Dell Technologies Proven Professional

--- a/packages/data/data/ec-council/programs/ec-council-certification-path.yaml
+++ b/packages/data/data/ec-council/programs/ec-council-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: ec-council-certification-path
+type: certuary
 name: EC-Council Certification Path
 description: >-
   EC-Council's cybersecurity certification pathway progressing from network

--- a/packages/data/data/fortinet/programs/fortinet-nse-path.yaml
+++ b/packages/data/data/fortinet/programs/fortinet-nse-path.yaml
@@ -1,4 +1,5 @@
 slug: fortinet-nse-path
+type: provider
 name: Fortinet NSE Certification Path
 description: >-
   Fortinet's Network Security Expert (NSE) program is an eight-level

--- a/packages/data/data/giac/programs/giac-cloud-security-path.yaml
+++ b/packages/data/data/giac/programs/giac-cloud-security-path.yaml
@@ -1,4 +1,5 @@
 slug: giac-cloud-security-path
+type: provider
 name: GIAC Cloud Security Certification Path
 description: >-
   A recommended progression through GIAC cloud security certifications,

--- a/packages/data/data/giac/programs/giac-cyber-defense-path.yaml
+++ b/packages/data/data/giac/programs/giac-cyber-defense-path.yaml
@@ -1,4 +1,5 @@
 slug: giac-cyber-defense-path
+type: provider
 name: GIAC Cyber Defense Certification Path
 description: >-
   A recommended progression through GIAC cyber defense certifications,

--- a/packages/data/data/giac/programs/giac-digital-forensics-path.yaml
+++ b/packages/data/data/giac/programs/giac-digital-forensics-path.yaml
@@ -1,4 +1,5 @@
 slug: giac-digital-forensics-path
+type: provider
 name: GIAC Digital Forensics & Incident Response Path
 description: >-
   A recommended progression through GIAC digital forensics and incident

--- a/packages/data/data/giac/programs/giac-penetration-testing-path.yaml
+++ b/packages/data/data/giac/programs/giac-penetration-testing-path.yaml
@@ -1,4 +1,5 @@
 slug: giac-penetration-testing-path
+type: provider
 name: GIAC Penetration Testing Certification Path
 description: >-
   A recommended progression through GIAC offensive security certifications,

--- a/packages/data/data/giac/programs/giac-security-expert-path.yaml
+++ b/packages/data/data/giac/programs/giac-security-expert-path.yaml
@@ -1,4 +1,6 @@
 slug: giac-security-expert-path
+type: provider
+designation: "GIAC Security Expert (GSE)"
 name: GIAC Security Expert (GSE) Path
 description: >-
   The path to the GIAC Security Expert (GSE) designation, the most

--- a/packages/data/data/htb/programs/htb-certification-path.yaml
+++ b/packages/data/data/htb/programs/htb-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: htb-certification-path
+type: certuary
 name: HTB Certification Path
 description: >-
   A recommended progression through Hack The Box certifications, starting with

--- a/packages/data/data/iapp/programs/cdpo-br.yaml
+++ b/packages/data/data/iapp/programs/cdpo-br.yaml
@@ -1,4 +1,6 @@
 slug: cdpo-br
+type: provider
+designation: "CDPO/BR"
 name: Certified Data Protection Officer/Brazil
 description: >-
   The CDPO/BR designation recognizes professionals with demonstrated

--- a/packages/data/data/iapp/programs/fip.yaml
+++ b/packages/data/data/iapp/programs/fip.yaml
@@ -1,4 +1,6 @@
 slug: fip
+type: provider
+designation: "Fellow of Information Privacy (FIP)"
 name: Fellow of Information Privacy
 description: >-
   The Fellow of Information Privacy (FIP) is IAPP's highest designation,

--- a/packages/data/data/ibm/programs/ibm-certification-path.yaml
+++ b/packages/data/data/ibm/programs/ibm-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: ibm-certification-path
+type: certuary
 name: IBM Certification Path
 description: >-
   A recommended learning path through IBM certifications, from foundational

--- a/packages/data/data/juniper/programs/juniper-certification-path.yaml
+++ b/packages/data/data/juniper/programs/juniper-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: juniper-certification-path
+type: provider
 name: Juniper Networks Certification Path
 description: >-
   A recommended learning path through Juniper Networks certifications, from

--- a/packages/data/data/linux-foundation/programs/golden-kubestronaut.yaml
+++ b/packages/data/data/linux-foundation/programs/golden-kubestronaut.yaml
@@ -1,4 +1,6 @@
 slug: golden-kubestronaut
+type: provider
+designation: "Golden Kubestronaut"
 name: Golden Kubestronaut
 description: >-
   The ultimate CNCF certification achievement. Earn all 16 Linux Foundation

--- a/packages/data/data/linux-foundation/programs/kubestronaut.yaml
+++ b/packages/data/data/linux-foundation/programs/kubestronaut.yaml
@@ -1,4 +1,6 @@
 slug: kubestronaut
+type: provider
+designation: "Kubestronaut"
 name: Kubestronaut
 description: >-
   Earn all five core CNCF Kubernetes certifications to become a Kubestronaut and

--- a/packages/data/data/nutanix/programs/nutanix-certification-path.yaml
+++ b/packages/data/data/nutanix/programs/nutanix-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: nutanix-certification-path
+type: certuary
 name: Nutanix Certification Path
 description: >-
   A recommended learning path through Nutanix certifications, from

--- a/packages/data/data/offsec/programs/offsec-certification-path.yaml
+++ b/packages/data/data/offsec/programs/offsec-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: offsec-certification-path
+type: provider
 name: OffSec Certification Path
 description: >-
   A recommended progression through Offensive Security certifications, starting

--- a/packages/data/data/open-group/programs/open-group-knowledge-path.yaml
+++ b/packages/data/data/open-group/programs/open-group-knowledge-path.yaml
@@ -1,4 +1,5 @@
 slug: open-group-knowledge-path
+type: provider
 name: Open Group Knowledge Certification Path
 description: >-
   A recommended learning path through The Open Group's knowledge-based

--- a/packages/data/data/open-group/programs/open-group-professional-path.yaml
+++ b/packages/data/data/open-group/programs/open-group-professional-path.yaml
@@ -1,4 +1,5 @@
 slug: open-group-professional-path
+type: provider
 name: Open Group Professional Certification Path
 description: >-
   The Open Group's experience-based professional certification path for IT

--- a/packages/data/data/oracle/programs/oracle-certification-path.yaml
+++ b/packages/data/data/oracle/programs/oracle-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: oracle-certification-path
+type: certuary
 name: Oracle Certification Path
 description: >-
   A recommended learning path through Oracle certifications, from foundational

--- a/packages/data/data/peoplecert/programs/itil-certification-path.yaml
+++ b/packages/data/data/peoplecert/programs/itil-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: itil-certification-path
+type: provider
 name: ITIL 4 Certification Path
 description: >-
   The ITIL 4 certification scheme provides a comprehensive framework for

--- a/packages/data/data/peoplecert/programs/itil-managing-professional.yaml
+++ b/packages/data/data/peoplecert/programs/itil-managing-professional.yaml
@@ -1,4 +1,6 @@
 slug: itil-managing-professional
+type: provider
+designation: "ITIL 4 Managing Professional"
 name: ITIL 4 Managing Professional
 description: >-
   The ITIL 4 Managing Professional designation provides practical and technical

--- a/packages/data/data/peoplecert/programs/itil-practice-manager.yaml
+++ b/packages/data/data/peoplecert/programs/itil-practice-manager.yaml
@@ -1,4 +1,6 @@
 slug: itil-practice-manager
+type: provider
+designation: "ITIL 4 Practice Manager"
 name: ITIL 4 Practice Manager
 description: >-
   The ITIL 4 Practice Manager designation validates competency in specific

--- a/packages/data/data/peoplecert/programs/itil-strategic-leader.yaml
+++ b/packages/data/data/peoplecert/programs/itil-strategic-leader.yaml
@@ -1,4 +1,6 @@
 slug: itil-strategic-leader
+type: provider
+designation: "ITIL 4 Strategic Leader"
 name: ITIL 4 Strategic Leader
 description: >-
   The ITIL 4 Strategic Leader designation demonstrates that the professional

--- a/packages/data/data/pmi/programs/pmi-certification-path.yaml
+++ b/packages/data/data/pmi/programs/pmi-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: pmi-certification-path
+type: certuary
 name: PMI Certification Path
 description: >-
   PMI's certification pathway progressing from foundational project management

--- a/packages/data/data/red-hat/programs/red-hat-certification-path.yaml
+++ b/packages/data/data/red-hat/programs/red-hat-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: red-hat-certification-path
+type: provider
 name: Red Hat Certification Path
 description: >-
   Red Hat's tiered certification framework progressing from foundational

--- a/packages/data/data/sabsa/programs/sabsa-certification-path.yaml
+++ b/packages/data/data/sabsa/programs/sabsa-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: sabsa-certification-path
+type: provider
 name: SABSA Certification Path
 description: >-
   The SABSA certification programme provides a structured path for enterprise

--- a/packages/data/data/salesforce/programs/salesforce-certification-path.yaml
+++ b/packages/data/data/salesforce/programs/salesforce-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: salesforce-certification-path
+type: certuary
 name: Salesforce Certification Path
 description: >-
   A recommended learning path through Salesforce certifications, from

--- a/packages/data/data/sap/programs/sap-certification-path.yaml
+++ b/packages/data/data/sap/programs/sap-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: sap-certification-path
+type: certuary
 name: SAP Certification Path
 description: >-
   A recommended learning path through SAP certifications, from foundational

--- a/packages/data/data/scaled-agile/programs/safe-certification-path.yaml
+++ b/packages/data/data/scaled-agile/programs/safe-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: safe-certification-path
+type: provider
 name: SAFe Certification Path
 description: >-
   The Scaled Agile Framework certification path guides practitioners from

--- a/packages/data/data/scrum-alliance/programs/scrum-alliance-agile-leadership-path.yaml
+++ b/packages/data/data/scrum-alliance/programs/scrum-alliance-agile-leadership-path.yaml
@@ -1,4 +1,5 @@
 slug: scrum-alliance-agile-leadership-path
+type: provider
 name: Scrum Alliance Agile Leadership Path
 description: >-
   Scrum Alliance's Certified Agile Leadership program develops agile

--- a/packages/data/data/scrum-alliance/programs/scrum-alliance-certification-path.yaml
+++ b/packages/data/data/scrum-alliance/programs/scrum-alliance-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: scrum-alliance-certification-path
+type: provider
 name: Scrum Alliance Certification Path
 description: >-
   Scrum Alliance's certification pathway progresses from foundational

--- a/packages/data/data/scrum-org/programs/scrum-org-certification-path.yaml
+++ b/packages/data/data/scrum-org/programs/scrum-org-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: scrum-org-certification-path
+type: certuary
 name: Scrum.org Certification Path
 description: >-
   Scrum.org's Professional Scrum certification pathway progressing from

--- a/packages/data/data/servicenow/programs/servicenow-certification-path.yaml
+++ b/packages/data/data/servicenow/programs/servicenow-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: servicenow-certification-path
+type: certuary
 name: ServiceNow Certification Path
 description: >-
   A recommended learning path through ServiceNow certifications, from

--- a/packages/data/data/snowflake/programs/snowflake-certification-path.yaml
+++ b/packages/data/data/snowflake/programs/snowflake-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: snowflake-certification-path
+type: provider
 name: Snowflake SnowPro Certification Path
 description: >-
   Snowflake's SnowPro certification framework progressing from the

--- a/packages/data/data/splunk/programs/splunk-certification-path.yaml
+++ b/packages/data/data/splunk/programs/splunk-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: splunk-certification-path
+type: certuary
 name: Splunk Certification Path
 description: >-
   A recommended learning path through Splunk certifications, from foundational

--- a/packages/data/data/vmware/programs/vmware-certification-path.yaml
+++ b/packages/data/data/vmware/programs/vmware-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: vmware-certification-path
+type: certuary
 name: VMware Certification Path
 description: >-
   VMware by Broadcom offers a tiered certification framework progressing

--- a/packages/data/data/zscaler/programs/zscaler-certification-path.yaml
+++ b/packages/data/data/zscaler/programs/zscaler-certification-path.yaml
@@ -1,4 +1,5 @@
 slug: zscaler-certification-path
+type: certuary
 name: Zscaler Certification Path
 description: >-
   A recommended learning path through Zscaler certifications, from

--- a/packages/data/scripts/generate.ts
+++ b/packages/data/scripts/generate.ts
@@ -127,11 +127,13 @@ function generate() {
         const raw = readYaml(path.join(programsDir, programFile), RawProgramSchema);
         programs.push({
           slug: raw.slug,
+          type: raw.type,
           name: raw.name,
           providerSlug: rawProvider.slug,
           description: raw.description,
           website: raw.website,
           status: raw.status,
+          ...(raw.designation ? { designation: raw.designation } : {}),
           requiredCerts: raw.required_certs ?? [],
           phases: (raw.phases ?? []).map((p) => ({
             name: p.name,

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ProgramCompletionCriteria,
   ProgramPhase,
   ProgramStatus,
+  ProgramType,
   Provider,
   QuestionCount,
 } from "./types.js";

--- a/packages/data/src/schemas.ts
+++ b/packages/data/src/schemas.ts
@@ -142,13 +142,17 @@ const ProgramPhaseSchema = z
   })
   .strict();
 
+const ProgramTypeSchema = z.enum(["provider", "certuary", "community"]);
+
 export const RawProgramSchema = z
   .object({
     slug: z.string(),
+    type: ProgramTypeSchema,
     name: z.string(),
     description: z.string(),
     website: z.string().url(),
     status: z.enum(["active", "retired"]),
+    designation: z.string().optional(),
     required_certs: z.array(z.string()).optional(),
     phases: z.array(ProgramPhaseSchema).optional(),
     ordering_strategies: z

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -73,6 +73,8 @@ export interface Certification {
   sourceOfTruthUrl?: string;
 }
 
+export type ProgramType = "provider" | "certuary" | "community";
+
 export type ProgramStatus = "active" | "retired";
 
 export interface ProgramPhase {
@@ -95,11 +97,13 @@ export interface ProgramCompletionCriteria {
 
 export interface Program {
   slug: string;
+  type: ProgramType;
   name: string;
   providerSlug: string;
   description: string;
   website: string;
   status: ProgramStatus;
+  designation?: string;
   requiredCerts: string[];
   phases: ProgramPhase[];
   orderingStrategies?: OrderingStrategy[];


### PR DESCRIPTION
Audit all 48 programs to distinguish provider-supplied programs from
certuary-curated paths. Adds a `type` field ("provider", "certuary",
"community") and an optional `designation` field for programs that grant
an official title upon completion.

- 32 programs classified as "provider" (official frameworks/tracks)
- 16 programs classified as "certuary" (curated by this project)
- 8 programs with official designations (Kubestronaut, GSE, ITIL MP/SL/PM, FIP, CDPO/BR)
- UI updated to show type badges and designation info on both list and detail pages

https://claude.ai/code/session_01QoAi14yTh49c6tFSRPJCSn