### PR TITLE
feat(home): add hero, filters, and clickable tag chips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        with:
+          version: 10.11.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Debug environment
+        run: |
+          echo "pnpm: $(pnpm --version)"
+          echo "node: $(node --version)"
+          echo "lockfile bytes: $(wc -c < pnpm-lock.yaml)"
+          echo "lockfile YAML doc separators: $(grep -c '^---$' pnpm-lock.yaml || echo 0)"
+          echo "lockfile head:"
+          head -5 pnpm-lock.yaml
+          echo "file type:"
+          file pnpm-lock.yaml
+
       - run: pnpm install --frozen-lockfile
 
       - name: Validate data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10.11.0
 
@@ -25,17 +25,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Debug environment
-        run: |
-          echo "pnpm: $(pnpm --version)"
-          echo "node: $(node --version)"
-          echo "lockfile bytes: $(wc -c < pnpm-lock.yaml)"
-          echo "lockfile YAML doc separators: $(grep -c '^---$' pnpm-lock.yaml || echo 0)"
-          echo "lockfile head:"
-          head -5 pnpm-lock.yaml
-          echo "file type:"
-          file pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        with:
+          version: 10.11.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10.11.0
 

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -1,37 +1,303 @@
-import { Link } from "react-router";
-import { getAllCerts, getProviderBySlug } from "@certuary/data";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { useMemo, useCallback } from "react";
+import { Link, useSearchParams } from "react-router";
+import {
+  getAllCerts,
+  getAllProviders,
+  getProviderBySlug,
+} from "@certuary/data";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EXPERIENCE_LEVELS, getCertLevel } from "@/lib/experience-levels";
+import { Map, GitCompare, Layers, Search, X } from "lucide-react";
+
+const ENTRY_POINTS = [
+  {
+    to: "/path-builder",
+    title: "Plan your path",
+    description: "Pick targets and we'll resolve the prerequisites.",
+    Icon: Map,
+  },
+  {
+    to: "/compare",
+    title: "Compare certs",
+    description: "Side-by-side breakdown of cost, format, and content.",
+    Icon: GitCompare,
+  },
+  {
+    to: "/domains",
+    title: "Explore by domain",
+    description: "Browse exam topics across providers.",
+    Icon: Layers,
+  },
+];
+
+function useHomeFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const q = searchParams.get("q") ?? "";
+  const provider = searchParams.get("provider") ?? "";
+  const level = searchParams.get("level") ?? "";
+  const status = searchParams.get("status") ?? "active";
+  const tag = searchParams.get("tag") ?? "";
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value) next.set(key, value);
+          else next.delete(key);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [setSearchParams]);
+
+  return { q, provider, level, status, tag, setParam, clearAll };
+}
 
 export function HomePage() {
-  const certs = getAllCerts();
+  const allCerts = useMemo(() => getAllCerts(), []);
+  const providers = useMemo(() => getAllProviders(), []);
+  const { q, provider, level, status, tag, setParam, clearAll } =
+    useHomeFilters();
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return allCerts.filter((cert) => {
+      if (status !== "all" && cert.status !== status) return false;
+      if (provider && cert.providerSlug !== provider) return false;
+      if (level && getCertLevel(cert) !== level) return false;
+      if (tag && !cert.tags.includes(tag)) return false;
+      if (needle) {
+        const providerName =
+          getProviderBySlug(cert.providerSlug)?.name ?? "";
+        const haystack = [
+          cert.name,
+          cert.shortName ?? "",
+          providerName,
+          ...cert.tags,
+        ]
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [allCerts, q, provider, level, status, tag]);
+
+  const hasFilters =
+    !!q || !!provider || !!level || status !== "active" || !!tag;
+
+  const toggleTag = useCallback(
+    (next: string) => {
+      setParam("tag", next === tag ? "" : next);
+    },
+    [tag, setParam],
+  );
 
   return (
-    <div>
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold">IT Certifications</h1>
-        <p className="mt-2 text-muted-foreground">
-          Browse and compare IT certifications across providers.
-        </p>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {certs.map((cert) => {
-          const provider = getProviderBySlug(cert.providerSlug);
-          return (
-            <Link key={cert.slug} to={`/cert/${cert.slug}`} className="group">
-              <Card className="h-full transition-shadow hover:shadow-md">
+    <div className="space-y-10">
+      <section className="space-y-5">
+        <div>
+          <h1 className="text-4xl font-bold tracking-tight">
+            Find your next IT certification
+          </h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            Browse {allCerts.length} certifications from {providers.length}{" "}
+            providers. Plan a learning path, compare options, or explore by
+            exam domain.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {ENTRY_POINTS.map(({ to, title, description, Icon }) => (
+            <Link
+              key={to}
+              to={to}
+              className="group rounded-lg border border-border bg-card p-4 transition-colors hover:border-primary"
+            >
+              <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+              <div className="mt-2 font-medium transition-colors group-hover:text-primary">
+                {title}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {description}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="text-2xl font-bold">Browse certifications</h2>
+          <p className="text-sm text-muted-foreground" aria-live="polite">
+            Showing {filtered.length} of {allCerts.length}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative min-w-[220px] flex-1 sm:max-w-md">
+            <Search
+              className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <input
+              type="search"
+              value={q}
+              onChange={(e) => setParam("q", e.target.value)}
+              placeholder="Search by name, provider, or tag..."
+              className="w-full rounded border border-border bg-background py-1.5 pl-8 pr-3 text-sm"
+              aria-label="Search certifications"
+            />
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <label className="text-sm font-medium" htmlFor="filter-provider">
+              Provider:
+            </label>
+            <select
+              id="filter-provider"
+              className="rounded border border-border bg-background px-2 py-1 text-sm"
+              value={provider}
+              onChange={(e) => setParam("provider", e.target.value)}
+            >
+              <option value="">All</option>
+              {providers.map((p) => (
+                <option key={p.slug} value={p.slug}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <label className="text-sm font-medium" htmlFor="filter-level">
+              Level:
+            </label>
+            <select
+              id="filter-level"
+              className="rounded border border-border bg-background px-2 py-1 text-sm"
+              value={level}
+              onChange={(e) => setParam("level", e.target.value)}
+            >
+              <option value="">All</option>
+              {EXPERIENCE_LEVELS.map((l) => (
+                <option key={l.key} value={l.key}>
+                  {l.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <label className="text-sm font-medium" htmlFor="filter-status">
+              Status:
+            </label>
+            <select
+              id="filter-status"
+              className="rounded border border-border bg-background px-2 py-1 text-sm"
+              value={status}
+              onChange={(e) => setParam("status", e.target.value)}
+            >
+              <option value="active">Active</option>
+              <option value="retiring">Retiring</option>
+              <option value="retired">Retired</option>
+              <option value="all">All</option>
+            </select>
+          </div>
+
+          {hasFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearAll}
+              className="gap-1 text-muted-foreground"
+            >
+              <X className="h-3 w-3" />
+              Clear filters
+            </Button>
+          )}
+        </div>
+
+        {tag && (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Filtering by tag:</span>
+            <Badge variant="default">{tag}</Badge>
+            <button
+              onClick={() => setParam("tag", "")}
+              className="text-xs underline hover:text-foreground"
+            >
+              clear
+            </button>
+          </p>
+        )}
+      </section>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <h3 className="text-lg font-medium">
+            No certifications match your filters
+          </h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Try clearing filters or broadening your search.
+          </p>
+          {hasFilters && (
+            <Button
+              onClick={clearAll}
+              variant="outline"
+              size="sm"
+              className="mt-4"
+            >
+              Clear all filters
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((cert) => {
+            const cardProvider = getProviderBySlug(cert.providerSlug);
+            return (
+              <Card
+                key={cert.slug}
+                className="group relative h-full transition-shadow hover:shadow-md"
+              >
+                <Link
+                  to={`/cert/${cert.slug}`}
+                  className="absolute inset-0 z-0 rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  aria-label={cert.name}
+                />
                 <CardHeader>
                   <div className="flex items-center justify-between">
                     <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {provider?.name ?? cert.providerSlug}
+                      {cardProvider?.name ?? cert.providerSlug}
                     </span>
                     <Badge
-                      variant={cert.status === "active" ? "default" : cert.status === "retiring" ? "outline" : "destructive"}
+                      variant={
+                        cert.status === "active"
+                          ? "default"
+                          : cert.status === "retiring"
+                            ? "outline"
+                            : "destructive"
+                      }
                     >
                       {cert.status}
                     </Badge>
                   </div>
-                  <CardTitle className="text-lg group-hover:text-primary transition-colors">
+                  <CardTitle className="text-lg transition-colors group-hover:text-primary">
                     {cert.shortName ?? cert.name}
                   </CardTitle>
                   <CardDescription className="line-clamp-2">
@@ -39,22 +305,36 @@ export function HomePage() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="flex flex-wrap gap-1">
-                    {cert.tags.slice(0, 3).map((tag) => (
-                      <Badge key={tag} variant="secondary">
-                        {tag}
-                      </Badge>
+                  <div className="relative z-10 flex flex-wrap gap-1">
+                    {cert.tags.slice(0, 3).map((t) => (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() => toggleTag(t)}
+                        aria-label={`Filter by tag ${t}`}
+                        aria-pressed={t === tag}
+                        className="rounded-full"
+                      >
+                        <Badge
+                          variant={t === tag ? "default" : "secondary"}
+                          className="cursor-pointer transition-colors hover:bg-primary hover:text-primary-foreground"
+                        >
+                          {t}
+                        </Badge>
+                      </button>
                     ))}
                   </div>
                   {cert.cost && (
-                    <p className="mt-3 text-sm font-medium">{cert.cost}</p>
+                    <p className="relative z-10 mt-3 text-sm font-medium">
+                      {cert.cost}
+                    </p>
                   )}
                 </CardContent>
               </Card>
-            </Link>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import {
   getAllCerts,
@@ -16,6 +16,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EXPERIENCE_LEVELS, getCertLevel } from "@/lib/experience-levels";
 import { Map, GitCompare, Layers, Search, X } from "lucide-react";
+
+const SEARCH_DEBOUNCE_MS = 250;
 
 const ENTRY_POINTS = [
   {
@@ -75,32 +77,60 @@ export function HomePage() {
   const { q, provider, level, status, tag, setParam, clearAll } =
     useHomeFilters();
 
+  // Local input mirrors the URL but updates instantly while the user types;
+  // URL syncs after a short debounce so router re-renders don't fire on
+  // every keystroke and history doesn't churn.
+  const [searchInput, setSearchInput] = useState(q);
+  useEffect(() => {
+    setSearchInput(q);
+  }, [q]);
+  useEffect(() => {
+    if (searchInput === q) return;
+    const timer = setTimeout(
+      () => setParam("q", searchInput),
+      SEARCH_DEBOUNCE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [searchInput, q, setParam]);
+
+  // Pre-compute provider name, level, and a lowercased search haystack once
+  // so the filter loop stays O(n) without per-cert lookups or string joins.
+  const enriched = useMemo(
+    () =>
+      allCerts.map((cert) => {
+        const providerName =
+          getProviderBySlug(cert.providerSlug)?.name ?? cert.providerSlug;
+        return {
+          cert,
+          providerName,
+          level: getCertLevel(cert),
+          searchHaystack: [
+            cert.name,
+            cert.shortName ?? "",
+            providerName,
+            ...cert.tags,
+          ]
+            .join(" ")
+            .toLowerCase(),
+        };
+      }),
+    [allCerts],
+  );
+
   const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    return allCerts.filter((cert) => {
+    const needle = searchInput.trim().toLowerCase();
+    return enriched.filter(({ cert, level: certLevel, searchHaystack }) => {
       if (status !== "all" && cert.status !== status) return false;
       if (provider && cert.providerSlug !== provider) return false;
-      if (level && getCertLevel(cert) !== level) return false;
+      if (level && certLevel !== level) return false;
       if (tag && !cert.tags.includes(tag)) return false;
-      if (needle) {
-        const providerName =
-          getProviderBySlug(cert.providerSlug)?.name ?? "";
-        const haystack = [
-          cert.name,
-          cert.shortName ?? "",
-          providerName,
-          ...cert.tags,
-        ]
-          .join(" ")
-          .toLowerCase();
-        if (!haystack.includes(needle)) return false;
-      }
+      if (needle && !searchHaystack.includes(needle)) return false;
       return true;
     });
-  }, [allCerts, q, provider, level, status, tag]);
+  }, [enriched, provider, level, status, tag, searchInput]);
 
   const hasFilters =
-    !!q || !!provider || !!level || status !== "active" || !!tag;
+    !!searchInput || !!provider || !!level || status !== "active" || !!tag;
 
   const toggleTag = useCallback(
     (next: string) => {
@@ -157,8 +187,8 @@ export function HomePage() {
             />
             <input
               type="search"
-              value={q}
-              onChange={(e) => setParam("q", e.target.value)}
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search by name, provider, or tag..."
               className="w-full rounded border border-border bg-background py-1.5 pl-8 pr-3 text-sm"
               aria-label="Search certifications"
@@ -268,71 +298,68 @@ export function HomePage() {
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filtered.map((cert) => {
-            const cardProvider = getProviderBySlug(cert.providerSlug);
-            return (
-              <Card
-                key={cert.slug}
-                className="group relative h-full transition-shadow hover:shadow-md"
-              >
-                <Link
-                  to={`/cert/${cert.slug}`}
-                  className="absolute inset-0 z-0 rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                  aria-label={cert.name}
-                />
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {cardProvider?.name ?? cert.providerSlug}
-                    </span>
-                    <Badge
-                      variant={
-                        cert.status === "active"
-                          ? "default"
-                          : cert.status === "retiring"
-                            ? "outline"
-                            : "destructive"
-                      }
-                    >
-                      {cert.status}
-                    </Badge>
-                  </div>
-                  <CardTitle className="text-lg transition-colors group-hover:text-primary">
+          {filtered.map(({ cert, providerName }) => (
+            <Card
+              key={cert.slug}
+              className="group relative h-full transition-shadow hover:shadow-md"
+            >
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {providerName}
+                  </span>
+                  <Badge
+                    variant={
+                      cert.status === "active"
+                        ? "default"
+                        : cert.status === "retiring"
+                          ? "outline"
+                          : "destructive"
+                    }
+                  >
+                    {cert.status}
+                  </Badge>
+                </div>
+                <CardTitle className="text-lg">
+                  <Link
+                    to={`/cert/${cert.slug}`}
+                    className="transition-colors group-hover:text-primary after:absolute after:inset-0 after:rounded-lg focus-visible:outline-none focus-visible:after:outline-2 focus-visible:after:outline-offset-2 focus-visible:after:outline-primary"
+                  >
                     {cert.shortName ?? cert.name}
-                  </CardTitle>
-                  <CardDescription className="line-clamp-2">
-                    {cert.description}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="relative z-10 flex flex-wrap gap-1">
-                    {cert.tags.slice(0, 3).map((t) => (
-                      <button
-                        key={t}
-                        type="button"
-                        onClick={() => toggleTag(t)}
-                        aria-label={`Filter by tag ${t}`}
-                        aria-pressed={t === tag}
-                        className="rounded-full"
+                  </Link>
+                </CardTitle>
+                <CardDescription className="line-clamp-2">
+                  {cert.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="relative z-10 flex flex-wrap gap-1">
+                  {cert.tags.slice(0, 3).map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => toggleTag(t)}
+                      aria-label={`Filter by tag ${t}`}
+                      aria-pressed={t === tag}
+                      className="rounded-full"
+                    >
+                      <Badge
+                        variant={t === tag ? "default" : "secondary"}
+                        className="cursor-pointer transition-colors hover:bg-primary hover:text-primary-foreground"
                       >
-                        <Badge
-                          variant={t === tag ? "default" : "secondary"}
-                          className="cursor-pointer transition-colors hover:bg-primary hover:text-primary-foreground"
-                        >
-                          {t}
-                        </Badge>
-                      </button>
-                    ))}
-                  </div>
-                  {cert.cost && (
-                    <p className="relative z-10 mt-3 text-sm font-medium">
-                      {cert.cost}
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })}
+                        {t}
+                      </Badge>
+                    </button>
+                  ))}
+                </div>
+                {cert.cost && (
+                  <p className="relative z-10 mt-3 text-sm font-medium">
+                    {cert.cost}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          ))}
         </div>
       )}
     </div>

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -4,6 +4,7 @@ import {
   getAllCerts,
   getAllProviders,
   getProviderBySlug,
+  type Provider,
 } from "@certuary/data";
 import {
   Card,
@@ -18,6 +19,16 @@ import { EXPERIENCE_LEVELS, getCertLevel } from "@/lib/experience-levels";
 import { Map, GitCompare, Layers, Search, X } from "lucide-react";
 
 const SEARCH_DEBOUNCE_MS = 250;
+
+const STATUSES = ["active", "retiring", "retired", "all"] as const;
+type StatusFilter = (typeof STATUSES)[number];
+const DEFAULT_STATUS: StatusFilter = "active";
+const STATUS_LABELS: Record<StatusFilter, string> = {
+  active: "Active",
+  retiring: "Retiring",
+  retired: "Retired",
+  all: "All",
+};
 
 const ENTRY_POINTS = [
   {
@@ -40,14 +51,35 @@ const ENTRY_POINTS = [
   },
 ];
 
-function useHomeFilters() {
+function isStatus(value: string): value is StatusFilter {
+  return (STATUSES as readonly string[]).includes(value);
+}
+
+function useHomeFilters(providers: Provider[]) {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const q = searchParams.get("q") ?? "";
-  const provider = searchParams.get("provider") ?? "";
-  const level = searchParams.get("level") ?? "";
-  const status = searchParams.get("status") ?? "active";
-  const tag = searchParams.get("tag") ?? "";
+  const validProviderSlugs = useMemo(
+    () => new Set(providers.map((p) => p.slug)),
+    [providers],
+  );
+  const validLevelKeys = useMemo(
+    () => new Set<string>(EXPERIENCE_LEVELS.map((l) => l.key)),
+    [],
+  );
+
+  // Normalize URL params against known option sets. Unknown values fall
+  // back to "no filter" so a stale or hand-edited URL doesn't filter out
+  // every card with no obvious recovery path.
+  const rawQ = searchParams.get("q") ?? "";
+  const providerParam = searchParams.get("provider") ?? "";
+  const provider = validProviderSlugs.has(providerParam) ? providerParam : "";
+  const levelParam = searchParams.get("level") ?? "";
+  const level = validLevelKeys.has(levelParam) ? levelParam : "";
+  const statusParam = searchParams.get("status") ?? "";
+  const status: StatusFilter = isStatus(statusParam)
+    ? statusParam
+    : DEFAULT_STATUS;
+  const tag = (searchParams.get("tag") ?? "").toLowerCase();
 
   const setParam = useCallback(
     (key: string, value: string) => {
@@ -64,34 +96,54 @@ function useHomeFilters() {
     [setSearchParams],
   );
 
-  const clearAll = useCallback(() => {
-    setSearchParams(new URLSearchParams(), { replace: true });
-  }, [setSearchParams]);
-
-  return { q, provider, level, status, tag, setParam, clearAll };
-}
-
-export function HomePage() {
-  const allCerts = useMemo(() => getAllCerts(), []);
-  const providers = useMemo(() => getAllProviders(), []);
-  const { q, provider, level, status, tag, setParam, clearAll } =
-    useHomeFilters();
-
-  // Local input mirrors the URL but updates instantly while the user types;
-  // URL syncs after a short debounce so router re-renders don't fire on
-  // every keystroke and history doesn't churn.
-  const [searchInput, setSearchInput] = useState(q);
+  // Local input mirrors the URL but updates instantly; URL syncs after a
+  // short debounce so router re-renders and history don't churn while typing.
+  const [searchInput, setSearchInput] = useState(rawQ);
   useEffect(() => {
-    setSearchInput(q);
-  }, [q]);
+    setSearchInput(rawQ);
+  }, [rawQ]);
   useEffect(() => {
-    if (searchInput === q) return;
+    if (searchInput === rawQ) return;
     const timer = setTimeout(
       () => setParam("q", searchInput),
       SEARCH_DEBOUNCE_MS,
     );
     return () => clearTimeout(timer);
-  }, [searchInput, q, setParam]);
+  }, [searchInput, rawQ, setParam]);
+
+  const clearAll = useCallback(() => {
+    // Reset local search before clearing URL so the next render's debounce
+    // effect sees searchInput === rawQ ("") and doesn't re-write the old
+    // query a moment after the user clicked clear.
+    setSearchInput("");
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [setSearchParams]);
+
+  return {
+    searchInput,
+    setSearchInput,
+    provider,
+    level,
+    status,
+    tag,
+    setParam,
+    clearAll,
+  };
+}
+
+export function HomePage() {
+  const allCerts = useMemo(() => getAllCerts(), []);
+  const providers = useMemo(() => getAllProviders(), []);
+  const {
+    searchInput,
+    setSearchInput,
+    provider,
+    level,
+    status,
+    tag,
+    setParam,
+    clearAll,
+  } = useHomeFilters(providers);
 
   // Pre-compute provider name, level, and a lowercased search haystack once
   // so the filter loop stays O(n) without per-cert lookups or string joins.
@@ -130,11 +182,16 @@ export function HomePage() {
   }, [enriched, provider, level, status, tag, searchInput]);
 
   const hasFilters =
-    !!searchInput || !!provider || !!level || status !== "active" || !!tag;
+    !!searchInput ||
+    !!provider ||
+    !!level ||
+    status !== DEFAULT_STATUS ||
+    !!tag;
 
   const toggleTag = useCallback(
     (next: string) => {
-      setParam("tag", next === tag ? "" : next);
+      const normalized = next.toLowerCase();
+      setParam("tag", normalized === tag ? "" : normalized);
     },
     [tag, setParam],
   );
@@ -243,10 +300,11 @@ export function HomePage() {
               value={status}
               onChange={(e) => setParam("status", e.target.value)}
             >
-              <option value="active">Active</option>
-              <option value="retiring">Retiring</option>
-              <option value="retired">Retired</option>
-              <option value="all">All</option>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABELS[s]}
+                </option>
+              ))}
             </select>
           </div>
 
@@ -340,11 +398,11 @@ export function HomePage() {
                       type="button"
                       onClick={() => toggleTag(t)}
                       aria-label={`Filter by tag ${t}`}
-                      aria-pressed={t === tag}
+                      aria-pressed={t.toLowerCase() === tag}
                       className="rounded-full"
                     >
                       <Badge
-                        variant={t === tag ? "default" : "secondary"}
+                        variant={t.toLowerCase() === tag ? "default" : "secondary"}
                         className="cursor-pointer transition-colors hover:bg-primary hover:text-primary-foreground"
                       >
                         {t}


### PR DESCRIPTION
The home page rendered all 431 certs as an unfiltered card grid with no
search, filters, or orientation for first-time visitors. Add:

- Hero block with one-line value prop and three task-oriented entry
  points (Plan your path, Compare certs, Explore by domain).
- Filter bar with search (name/provider/tags), provider, level, and
  status. State is URL-persisted via search params (matches the pattern
  in heatmap.tsx and graph.tsx) and shareable. Status defaults to
  "active" so retired certs no longer dominate the first view.
- Result count and an empty state when filters return nothing.
- Tag chips on cards are now buttons that toggle a tag filter; the card
  link is rendered as a stretched overlay so tag clicks don't navigate.

https://claude.ai/code/session_01ThPCdzQfNyKPTSTp1iJR1y